### PR TITLE
Handle updated macOS universal2 package name for HELICS releases starting at 3.1.0

### DIFF
--- a/install/install-helics-binary.sh
+++ b/install/install-helics-binary.sh
@@ -11,8 +11,9 @@ pushd "$tmpdir" || exit
 case "$(uname -s)" in
 Linux*) platname="Linux-x86_64" && ext="tar.gz" ;;
 Darwin*)
-  dpkg --compare-versions "${HELICS_VERSION:1}" "lt" "3.1.0" && platname="macOS-x86_64" || platname="macOS-universal2"
-  ext="zip" ;;
+	dpkg --compare-versions "${HELICS_VERSION:1}" "lt" "3.1.0" && platname="macOS-x86_64" || platname="macOS-universal2"
+	ext="zip"
+	;;
 MINGW*) platname="win64" && ext="zip" ;;
 *) exit 1 ;;
 esac

--- a/install/install-helics-binary.sh
+++ b/install/install-helics-binary.sh
@@ -10,7 +10,9 @@ pushd "$tmpdir" || exit
 # Download HELICS release based on the platform
 case "$(uname -s)" in
 Linux*) platname="Linux-x86_64" && ext="tar.gz" ;;
-Darwin*) platname="macOS-x86_64" && ext="zip" ;;
+Darwin*)
+  dpkg --compare-versions "${HELICS_VERSION:1}" "lt" "3.1.0" && platname="macOS-x86_64" || platname="macOS-universal2"
+  ext="zip" ;;
 MINGW*) platname="win64" && ext="zip" ;;
 *) exit 1 ;;
 esac

--- a/install/install-helics-binary.sh
+++ b/install/install-helics-binary.sh
@@ -11,7 +11,15 @@ pushd "$tmpdir" || exit
 case "$(uname -s)" in
 Linux*) platname="Linux-x86_64" && ext="tar.gz" ;;
 Darwin*)
-	dpkg --compare-versions "${HELICS_VERSION:1}" "lt" "3.1.0" && platname="macOS-x86_64" || platname="macOS-universal2"
+	version_full="${HELICS_VERSION:1}"
+	major_ver=$(echo "${version_full}.0" | cut -d "." -f1)
+        minor_ver=$(echo "${version_full}.0" | cut -d "." -f2)
+	if [[ "${major_ver}" -gt "3" || ("${major_ver}" -eq "3" && "${minor_ver}" -ge "1") ]]
+	then
+		platname="macOS-universal2"
+	else
+		platname="macOS-x86_64"
+	fi
 	ext="zip"
 	;;
 MINGW*) platname="win64" && ext="zip" ;;

--- a/install/install-helics-binary.sh
+++ b/install/install-helics-binary.sh
@@ -13,9 +13,8 @@ Linux*) platname="Linux-x86_64" && ext="tar.gz" ;;
 Darwin*)
 	version_full="${HELICS_VERSION:1}"
 	major_ver=$(echo "${version_full}.0" | cut -d "." -f1)
-        minor_ver=$(echo "${version_full}.0" | cut -d "." -f2)
-	if [[ "${major_ver}" -gt "3" || ("${major_ver}" -eq "3" && "${minor_ver}" -ge "1") ]]
-	then
+	minor_ver=$(echo "${version_full}.0" | cut -d "." -f2)
+	if [[ "${major_ver}" -gt "3" || ("${major_ver}" -eq "3" && "${minor_ver}" -ge "1") ]]; then
 		platname="macOS-universal2"
 	else
 		platname="macOS-x86_64"


### PR DESCRIPTION
macOS releases starting at 3.1.0 use the universal2 platform tag instead of x86_64.